### PR TITLE
feat(s3-workdir): Add selected config sections to IgBaseTask

### DIFF
--- a/src/main/nextflow/executor/IgBaseTask.groovy
+++ b/src/main/nextflow/executor/IgBaseTask.groovy
@@ -72,6 +72,11 @@ abstract class IgBaseTask<T> implements IgniteCallable<T>, ComputeJob {
     protected Map sessionConfig;
 
     /**
+     * Config sections that have to be known to the task, taken from main session config
+     */
+    protected static final String[] RELEVANT_CONFIG_KEYS = [ "aws", "plugins", "cluster", "cleanup" ]
+
+    /**
      * Initialize the grid gain task wrapper
      *
      * @param task The task instance to be executed
@@ -195,11 +200,11 @@ abstract class IgBaseTask<T> implements IgniteCallable<T>, ComputeJob {
         "${getClass().simpleName}[taskId=${taskId}]"
     }
 
-    private ConfigMap getRelevantConfigSections(Map sessionConfig) {
+    private static ConfigMap getRelevantConfigSections(Map sessionConfig) {
         def configPart = new ConfigMap()
-        def relevantConfigKeys = ["aws", "plugins", "cluster"]
-        for (configKey in relevantConfigKeys) {
-            configPart.put(configKey, sessionConfig.get(configKey))
+        for (configKey in RELEVANT_CONFIG_KEYS) {
+            if ( sessionConfig.containsKey(configKey) )
+                configPart.put(configKey, sessionConfig.get(configKey))
         }
         configPart
     }

--- a/src/main/nextflow/executor/IgBaseTask.groovy
+++ b/src/main/nextflow/executor/IgBaseTask.groovy
@@ -15,6 +15,7 @@
  */
 package nextflow.executor
 
+import nextflow.Global
 import nextflow.config.ConfigMap
 
 import java.nio.channels.ClosedByInterruptException
@@ -120,6 +121,15 @@ abstract class IgBaseTask<T> implements IgniteCallable<T>, ComputeJob {
     @Override
     final T call() throws Exception {
         try {
+
+            /**
+             * Set sessionConfig to make AWS/S3FS config and credentials
+             * available before creating S3FileSystem during deserialize()
+             */
+            if ( sessionConfig != null ) {
+                Global.setConfig(sessionConfig)
+            }
+
             deserialize()
 
             /*

--- a/src/main/nextflow/executor/IgBaseTask.groovy
+++ b/src/main/nextflow/executor/IgBaseTask.groovy
@@ -15,6 +15,8 @@
  */
 package nextflow.executor
 
+import nextflow.config.ConfigMap
+
 import java.nio.channels.ClosedByInterruptException
 
 import groovy.transform.CompileStatic
@@ -64,6 +66,11 @@ abstract class IgBaseTask<T> implements IgniteCallable<T>, ComputeJob {
     protected transient TaskBean bean
 
     /**
+     * Provides access to sections of the Session config associated with the TaskRun object
+     */
+    protected Map sessionConfig;
+
+    /**
      * Initialize the grid gain task wrapper
      *
      * @param task The task instance to be executed
@@ -75,6 +82,7 @@ abstract class IgBaseTask<T> implements IgniteCallable<T>, ComputeJob {
         this.bean = new TaskBean(task)
         this.payload = KryoHelper.serialize(bean)
         this.resources = new TaskResources(task)
+        this.sessionConfig = getRelevantConfigSections(task.processor.session.config)
     }
 
     /** ONLY FOR TESTING PURPOSE */
@@ -177,4 +185,12 @@ abstract class IgBaseTask<T> implements IgniteCallable<T>, ComputeJob {
         "${getClass().simpleName}[taskId=${taskId}]"
     }
 
+    private ConfigMap getRelevantConfigSections(Map sessionConfig) {
+        def configPart = new ConfigMap()
+        def relevantConfigKeys = ["aws", "plugins", "cluster"]
+        for (configKey in relevantConfigKeys) {
+            configPart.put(configKey, sessionConfig.get(configKey))
+        }
+        configPart
+    }
 }


### PR DESCRIPTION
In order to access S3 Paths from Ignite daemon nodes, the S3FileSystem has to be configured, authenticated and initialized. 
This must happen prior to task execution and can be achieved by `Global.setConfig(sessionConfig)`.

But this implies the IgTasks have to have access to the `nextflow.config` of the Ignite master which is done by storing selected config sections in a field of the `IgBaseTask`.

TODO:

- [ ]  inject the config keys from another class since the IgBaseTask shouldn't have to know about which keys it needs